### PR TITLE
Set culture to US in SafeConvert to prevent format errors

### DIFF
--- a/src/NSC/Extensions/StringExts.cs
+++ b/src/NSC/Extensions/StringExts.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
+using System.Threading;
 
 namespace NetSwiftClient
 {
@@ -38,6 +39,9 @@ namespace NetSwiftClient
 
         public static object SafeConvert(this string s, Type t, Func<object> defaultValueGenerator)
         {
+            // Converting from US numbers formatting
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-us");
+
             if (String.IsNullOrEmpty(s))
                 return defaultValueGenerator();
             if (!t.IsValueType)


### PR DESCRIPTION
Invalid string format exception raised when converting from decimal values in fr_FR environnement : ex: "1.22" because default cultre (fr) notation is "1,22". Leading to object not being retrieved at all.
